### PR TITLE
fix: fix 'object reference not set to instance of an object' error wh…

### DIFF
--- a/Audacia.Mail.SendGrid/SendGridClient.cs
+++ b/Audacia.Mail.SendGrid/SendGridClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using SendGrid.Helpers.Mail;
@@ -51,8 +52,8 @@ namespace Audacia.Mail.SendGrid
 
 			var sendGridMessage = new SendGridMessage
 			{
-				Contents = { new Content { Type = message.Format.ToString(), Value = message.Body } },
-				From = new EmailAddress(message.Sender?.Address, message.Sender?.Name),
+                Contents = new List<Content> { new Content { Type = message.Format.ToString(), Value = message.Body } },
+                From = new EmailAddress(message.Sender?.Address, message.Sender?.Name),
 				Subject = message.Subject,
 				Attachments = message.Attachments.Select(a => new Attachment
 				{


### PR DESCRIPTION
fix 'object reference not set to instance of an object' when sending via mail message via SendGridClient.

| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ❌ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |