### PR TITLE
feat: added support for MailtrapClient to pass in host.

### DIFF
--- a/Audacia.Mail.Local/Audacia.Mail.Local.csproj
+++ b/Audacia.Mail.Local/Audacia.Mail.Local.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>Implementations of the Audacia.Mail interfaces for sending emails to a local machine for testing purposes.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.Log/Audacia.Mail.Log.csproj
+++ b/Audacia.Mail.Log/Audacia.Mail.Log.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>Implementations of the Audacia.Mail interfaces for logging emails to a console.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.MailKit/Audacia.Mail.MailKit.csproj
+++ b/Audacia.Mail.MailKit/Audacia.Mail.MailKit.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>Mailkit implementations for the Audacia.Mail interface.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.MailTrap/Audacia.Mail.MailTrap.csproj
+++ b/Audacia.Mail.MailTrap/Audacia.Mail.MailTrap.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>Mailtrap implementation of the Audacia.Mail interface.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.MailTrap/HostType.cs
+++ b/Audacia.Mail.MailTrap/HostType.cs
@@ -1,0 +1,18 @@
+﻿namespace Audacia.Mail.MailTrap
+{   
+    /// <summary>
+    /// Mailtrap host types enum.    
+    /// </summary>
+    public enum HostType
+    {
+        /// <summary>
+        /// Represents prodction host.
+        /// </summary>
+        Production,
+
+        /// <summary>
+        /// Represents test host.
+        /// </summary>
+        Test
+    }
+}

--- a/Audacia.Mail.MailTrap/HostType.cs
+++ b/Audacia.Mail.MailTrap/HostType.cs
@@ -6,13 +6,13 @@
     public enum HostType
     {
         /// <summary>
-        /// Represents production host.
-        /// </summary>
-        Production,
-
-        /// <summary>
         /// Represents test host.
         /// </summary>
-        Test
+        Test,
+        
+        /// <summary>
+        /// Represents production host.
+        /// </summary>
+        Production
     }
 }

--- a/Audacia.Mail.MailTrap/HostType.cs
+++ b/Audacia.Mail.MailTrap/HostType.cs
@@ -6,7 +6,7 @@
     public enum HostType
     {
         /// <summary>
-        /// Represents prodction host.
+        /// Represents production host.
         /// </summary>
         Production,
 

--- a/Audacia.Mail.MailTrap/MailtrapClient.cs
+++ b/Audacia.Mail.MailTrap/MailtrapClient.cs
@@ -5,11 +5,11 @@ namespace Audacia.Mail.MailTrap
 	/// <summary>Sends mail using the Mailtrap SMTP endpoint.</summary>
 	public class MailtrapClient : MailKitClient
 	{
-		private static SmtpSettings GetSettings(string username, string password)
+		private static SmtpSettings GetSettings(string username, string password, HostType hosttype)
 		{
 			return new SmtpSettings
 			{
-				Host = "smtp.mailtrap.io",
+				Host = MapHostTypes(hosttype),
 				UserName = username,
 				Password = password,
 				Port = 587
@@ -20,8 +20,17 @@ namespace Audacia.Mail.MailTrap
         /// <param name="username">The username for Mailtrap.</param>
         /// <param name="password">The password for Mailtrap.</param>
         public MailtrapClient(string username, string password)
-			: base(GetSettings(username, password))
+			: base(GetSettings(username, password, HostType.Test))
 		{
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MailtrapClient"/> class.</summary>
+        /// <param name="username">The username for Mailtrap.</param>
+        /// <param name="password">The password for Mailtrap.</param>
+		/// <param name="hosttype">The host type for Mailtrap.</param>
+        public MailtrapClient(string username, string password, HostType hosttype) 
+			: base(GetSettings(username, password, hosttype))
+		{		
 		}
 
         /// <summary>Initializes a new instance of the <see cref="MailtrapClient"/> class.</summary>
@@ -32,6 +41,21 @@ namespace Audacia.Mail.MailTrap
 			: this(username, password)
 		{
 			DefaultSender = defaultSender;
+		}
+
+		/// <summary>
+		/// Map the host type to the correct host value.
+		/// </summary>
+		/// <param name="hosttype">Type of Mailtrap host.</param>
+		/// <returns>Host value.</returns>
+		private static string MapHostTypes(HostType hosttype) 
+		{
+			return hosttype switch
+			{
+				HostType.Test => "smtp.mailtrap.io",
+				HostType.Production => "live.smtp.mailtrap.io",
+				_ => "smtp.mailtrap.io"
+            };
 		}
 	}
 }

--- a/Audacia.Mail.MailTrap/MailtrapClient.cs
+++ b/Audacia.Mail.MailTrap/MailtrapClient.cs
@@ -5,11 +5,11 @@ namespace Audacia.Mail.MailTrap
 	/// <summary>Sends mail using the Mailtrap SMTP endpoint.</summary>
 	public class MailtrapClient : MailKitClient
 	{
-		private static SmtpSettings GetSettings(string username, string password, HostType hosttype)
+		private static SmtpSettings GetSettings(string username, string password, HostType hostType)
 		{
 			return new SmtpSettings
 			{
-				Host = MapHostTypes(hosttype),
+				Host = MapHostTypes(hostType),
 				UserName = username,
 				Password = password,
 				Port = 587
@@ -27,9 +27,9 @@ namespace Audacia.Mail.MailTrap
         /// <summary>Initializes a new instance of the <see cref="MailtrapClient"/> class.</summary>
         /// <param name="username">The username for Mailtrap.</param>
         /// <param name="password">The password for Mailtrap.</param>
-		/// <param name="hosttype">The host type for Mailtrap.</param>
-        public MailtrapClient(string username, string password, HostType hosttype) 
-			: base(GetSettings(username, password, hosttype))
+		/// <param name="hostType">The host type for Mailtrap.</param>
+        public MailtrapClient(string username, string password, HostType hostType) 
+			: base(GetSettings(username, password, hostType))
 		{		
 		}
 
@@ -43,14 +43,12 @@ namespace Audacia.Mail.MailTrap
 			DefaultSender = defaultSender;
 		}
 
-		/// <summary>
-		/// Map the host type to the correct host value.
-		/// </summary>
-		/// <param name="hosttype">Type of Mailtrap host.</param>
-		/// <returns>Host value.</returns>
-		private static string MapHostTypes(HostType hosttype) 
+        /// <summary> Map the host type to the correct host value. </summary>
+        /// <param name="hostType">Type of Mailtrap host.</param>
+        /// <returns>Host value.</returns>
+        private static string MapHostTypes(HostType hostType) 
 		{
-			return hosttype switch
+			return hostType switch
 			{
 				HostType.Test => "smtp.mailtrap.io",
 				HostType.Production => "live.smtp.mailtrap.io",

--- a/Audacia.Mail.Mandrill/Audacia.Mail.Mandrill.csproj
+++ b/Audacia.Mail.Mandrill/Audacia.Mail.Mandrill.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>Mandrill implementations for the Audacia.Mail interface.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.Noop/Audacia.Mail.Noop.csproj
+++ b/Audacia.Mail.Noop/Audacia.Mail.Noop.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.SendGrid/Audacia.Mail.SendGrid.csproj
+++ b/Audacia.Mail.SendGrid/Audacia.Mail.SendGrid.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>SendGrid implementations of the Audacia.Mail interface</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Audacia.Mail.Test.App/Audacia.Mail.Test.App.csproj
+++ b/Audacia.Mail.Test.App/Audacia.Mail.Test.App.csproj
@@ -8,7 +8,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <Copyright>Copyright © Audacia 2019</Copyright>
-        <PackageVersion>1.3.0</PackageVersion>
+        <PackageVersion>1.3.1</PackageVersion>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/Audacia.Mail.Test.App/Program.cs
+++ b/Audacia.Mail.Test.App/Program.cs
@@ -4,73 +4,72 @@ using System.Threading.Tasks;
 using Audacia.Mail.Log;
 using Audacia.Random.Extensions;
 
-namespace Audacia.Mail.Test.App
+namespace Audacia.Mail.Test.App;
+
+internal static class Program
 {
-    internal static class Program
+    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Email addresses should be lower case.")]
+    private static async Task Main()
     {
-        [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Email addresses should be lower case.")]
-        private static async Task Main()
+        var localMailer = new LogMailClient((message) =>
         {
-            var localMailer = new LogMailClient((message) =>
-            {
-                Console.WriteLine(message);
-            });
+            Console.WriteLine(message);
+        });
 
-            using (localMailer)
-            {
-                var random = new System.Random();
+        using (localMailer)
+        {
+            var random = new System.Random();
 
-                for (var iteration = 1; iteration <= 10; iteration++)
+            for (var iteration = 1; iteration <= 10; iteration++)
+            {
+                var forenames = new[]
                 {
-                    var forenames = new[]
-                    {
-                        random.Boolean()
-                            ? random.MaleForename()
-                            : random.FemaleForename(),
-                        random.Boolean()
-                            ? random.MaleForename()
-                            : random.FemaleForename()
-                    };
+                    random.Boolean()
+                        ? random.MaleForename()
+                        : random.FemaleForename(),
+                    random.Boolean()
+                        ? random.MaleForename()
+                        : random.FemaleForename()
+                };
 
-                    var surnames = new[]
-                    {
-                        random.Surname(),
-                        random.Surname()
-                    };
+                var surnames = new[]
+                {
+                    random.Surname(),
+                    random.Surname()
+                };
 
-                    var message = new MailMessage
-                    {
-                        Format = MailFormat.Html,
-                        Sender = new MailAddress
-                            {
-                                Address = $"{forenames[0]}.{surnames[0]}@example.com".ToLowerInvariant(),
-                                Name = $"{forenames[0]} {surnames[0]}"
-                            },
-                        Recipients =
+                var message = new MailMessage
+                {
+                    Format = MailFormat.Html,
+                    Sender = new MailAddress
                         {
-                            new MailAddress
-                            {
-                                Address = $"{forenames[1]}.{surnames[1]}@example.com".ToLowerInvariant(),
-                                Name = $"{forenames[1]} {surnames[1]}"
-                            }
+                            Address = $"{forenames[0]}.{surnames[0]}@example.com".ToLowerInvariant(),
+                            Name = $"{forenames[0]} {surnames[0]}"
                         },
-                        Subject = $"Test {iteration}: {random.Word()} {random.Word()}",
-                        Body = $"<div><b>{random.Sentence()}</b></div>"
-                    };
+                    Recipients =
+                    {
+                        new MailAddress
+                        {
+                            Address = $"{forenames[1]}.{surnames[1]}@example.com".ToLowerInvariant(),
+                            Name = $"{forenames[1]} {surnames[1]}"
+                        }
+                    },
+                    Subject = $"Test {iteration}: {random.Word()} {random.Word()}",
+                    Body = $"<div><b>{random.Sentence()}</b></div>"
+                };
 
-                    await SendMailAsync(localMailer, message, iteration);
-                }
-
-                await Task.Delay(int.MaxValue).ConfigureAwait(false);
+                await SendMailAsync(localMailer, message, iteration);
             }
-        }
 
-        private static async Task SendMailAsync(LogMailClient localMailer, MailMessage message, int iteration)
-        {
-            await localMailer.SendAsync(message).ConfigureAwait(false);
-            Console.WriteLine($"Sent email #{iteration}");
-            await Task.Delay(1000).ConfigureAwait(false);
-            iteration++;
+            await Task.Delay(int.MaxValue).ConfigureAwait(false);
         }
+    }
+
+    private static async Task SendMailAsync(LogMailClient localMailer, MailMessage message, int iteration)
+    {
+        await localMailer.SendAsync(message).ConfigureAwait(false);
+        Console.WriteLine($"Sent email #{iteration}");
+        await Task.Delay(1000).ConfigureAwait(false);
+        iteration++;
     }
 }

--- a/Audacia.Mail/Audacia.Mail.csproj
+++ b/Audacia.Mail/Audacia.Mail.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
         <Authors>Audacia</Authors>
         <Description>Standardized interfaces for sending e-mail.</Description>
         <Copyright>Copyright © Audacia 2019</Copyright>

--- a/README.md
+++ b/README.md
@@ -343,7 +343,15 @@ public void Connect()
 Send mail to the Mailtrap server for testing purposes. Uses the MailKit SMTP implementation.
 ```csharp
 public MailtrapClient(string username, string password)
-    : base(GetSettings(username, password))
+    : base(GetSettings(username, password, HostType.Test))
+{
+}
+```
+
+You can also use Mailtrap sever for sending production emails.
+```csharp
+public MailtrapClient(string username, string password, HostType hosttype)
+    : base(GetSettings(username, password, hosttype))
 {
 }
 ```

--- a/README.md
+++ b/README.md
@@ -350,10 +350,14 @@ public MailtrapClient(string username, string password)
 
 You can also use Mailtrap sever for sending production emails.
 ```csharp
-public MailtrapClient(string username, string password, HostType hosttype)
-    : base(GetSettings(username, password, hosttype))
+public MailtrapClient(string username, string password, HostType hostType)
+    : base(GetSettings(username, password, hostType))
 {
 }
+```
+usage for production
+```csharp
+var mailTrapClient = new MailtrapClient("userName", "password", HostType.Production);
 ```
 
 `MailtrapClient` also inherits `MailKitClient` and similar to the `DevMailClient` it creates a new `SmtpSettings` object with the private method `GetSettings`.


### PR DESCRIPTION
| Action | Amended MailTrapClient to take in host as a parameter so this can be use in production  |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔/❌ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔/❌ |
| README updated | ✔|
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔/❌ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔/❌ |