### PR TITLE
fix: use Build.Directory.Props as the version source #207554

### DIFF
--- a/Audacia.Mail.Local/Audacia.Mail.Local.csproj
+++ b/Audacia.Mail.Local/Audacia.Mail.Local.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Implementations of the Audacia.Mail interfaces for sending emails to a local machine for testing purposes.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.Log/Audacia.Mail.Log.csproj
+++ b/Audacia.Mail.Log/Audacia.Mail.Log.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Implementations of the Audacia.Mail interfaces for logging emails to a console.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.MailKit/Audacia.Mail.MailKit.csproj
+++ b/Audacia.Mail.MailKit/Audacia.Mail.MailKit.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Mailkit implementations for the Audacia.Mail interface.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.MailTrap/Audacia.Mail.MailTrap.csproj
+++ b/Audacia.Mail.MailTrap/Audacia.Mail.MailTrap.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Mailtrap implementation of the Audacia.Mail interface.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.Mandrill/Audacia.Mail.Mandrill.csproj
+++ b/Audacia.Mail.Mandrill/Audacia.Mail.Mandrill.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Mandrill implementations for the Audacia.Mail interface.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.Noop/Audacia.Mail.Noop.csproj
+++ b/Audacia.Mail.Noop/Audacia.Mail.Noop.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.SendGrid/Audacia.Mail.SendGrid.csproj
+++ b/Audacia.Mail.SendGrid/Audacia.Mail.SendGrid.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <Copyright>Copyright © Audacia 2019</Copyright>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>SendGrid implementations of the Audacia.Mail interface</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.Test.API/Audacia.Mail.Test.API.csproj
+++ b/Audacia.Mail.Test.API/Audacia.Mail.Test.API.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Authors>Audacia</Authors>
-    <Version>1.3.5</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Audacia.Mail.Test.App/Audacia.Mail.Test.App.csproj
+++ b/Audacia.Mail.Test.App/Audacia.Mail.Test.App.csproj
@@ -4,7 +4,6 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Tests for Audacia.Mail interface using the Audacia.Mail.Local project.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Audacia.Mail.sln
+++ b/Audacia.Mail.sln
@@ -19,8 +19,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		build.yaml = build.yaml
-		README.md = README.md
 		CHANGELOG.md = CHANGELOG.md
+		Directory.Build.props = Directory.Build.props
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Audacia.Mail.Log", "Audacia.Mail.Log\Audacia.Mail.Log.csproj", "{EE577F2F-0757-46BA-B2F1-0C3E0BC67370}"

--- a/Audacia.Mail/Audacia.Mail.csproj
+++ b/Audacia.Mail/Audacia.Mail.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Authors>Audacia</Authors>
-        <Version>1.3.5</Version>
         <Description>Standardized interfaces for sending e-mail.</Description>
         <Copyright>Copyright © Audacia 2019</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
… #207554

### Version changed and CHANGELOG updated
- ❎ No version change required

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ❎ Changes do not require documentation

### Dependency licenses
- ❎ No new/upgraded dependencies

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR